### PR TITLE
support assume role

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,16 @@ metadata:
   name: myclusterset1
 spec:
   selector:
+    roleARN: "arn:aws:iam::123456789012:role/read-eks-cluster-role" # optional
     eksTags:
       foo: "bar"
   template:
     metadata:
       labels:
         env: "prod"
+      config:
+        awsAuthConfig:
+          roleARN: "arn:aws:iam::123456789012:role/argocd-auth-role" # optional
 EOF
 ```
 

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -27,6 +27,7 @@ type ClusterSetSpec struct {
 }
 
 type ClusterSelector struct {
+	RoleARN string            `json:"roleARN,omitempty"`
 	EKSTags map[string]string `json:"eksTags,omitempty"`
 }
 
@@ -36,6 +37,15 @@ type ClusterSecretTemplate struct {
 
 type ClusterSecretTemplateMetadata struct {
 	Labels map[string]string `json:"labels"`
+	Config ClusterSecretTemplateMetadataConfig `json:"config,omitempty"`
+}
+
+type ClusterSecretTemplateMetadataConfig struct {
+	AWSAuthConfig ClusterSecretTemplateMetadataConfigAwsAuthConfig `json:"awsAuthConfig,omitempty"`
+}
+
+type ClusterSecretTemplateMetadataConfigAwsAuthConfig struct {
+	RoleARN string `json:"roleARN,omitempty"`
 }
 
 // ClusterSetStatus defines the observed state of ClusterSet

--- a/charts/clusterset-controller/crds/clusterset.mumo.co_clustersets.yaml
+++ b/charts/clusterset-controller/crds/clusterset.mumo.co_clustersets.yaml
@@ -23,7 +23,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: ClusterSet is the Schema for the runners API
+      description: ClusterSet is the Schema for the ClusterSet API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -46,11 +46,21 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                roleARN:
+                  type: string
               type: object
             template:
               properties:
                 metadata:
                   properties:
+                    config:
+                      properties:
+                        awsAuthConfig:
+                          properties:
+                            roleARN:
+                              type: string
+                          type: object
+                      type: object
                     labels:
                       additionalProperties:
                         type: string

--- a/config/crd/bases/clusterset.mumo.co_clustersets.yaml
+++ b/config/crd/bases/clusterset.mumo.co_clustersets.yaml
@@ -1,17 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: clustersets.clusterset.mumo.co
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.lastSyncTime
-    name: Last Sync
-    type: date
   group: clusterset.mumo.co
   names:
     kind: ClusterSet
@@ -19,84 +15,98 @@ spec:
     plural: clustersets
     singular: clusterset
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ClusterSet is the Schema for the ClusterSet API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ClusterSetSpec defines the desired state of ClusterSet
-          properties:
-            selector:
-              properties:
-                eksTags:
-                  additionalProperties:
-                    type: string
-                  type: object
-              type: object
-            template:
-              properties:
-                metadata:
-                  properties:
-                    labels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                  required:
-                  - labels
-                  type: object
-              required:
-              - metadata
-              type: object
-          required:
-          - template
-          type: object
-        status:
-          description: ClusterSetStatus defines the observed state of ClusterSet
-          properties:
-            clusters:
-              description: ClusterSetStatusClusters contains runner registration status
-              properties:
-                names:
-                  items:
-                    type: string
-                  type: array
-              type: object
-            lastSyncTime:
-              format: date-time
-              type: string
-            message:
-              type: string
-            phase:
-              type: string
-            reason:
-              type: string
-          required:
-          - clusters
-          - lastSyncTime
-          - message
-          - phase
-          - reason
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.lastSyncTime
+      name: Last Sync
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterSet is the Schema for the ClusterSet API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSetSpec defines the desired state of ClusterSet
+            properties:
+              selector:
+                properties:
+                  eksTags:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  roleARN:
+                    type: string
+                type: object
+              template:
+                properties:
+                  metadata:
+                    properties:
+                      config:
+                        properties:
+                          awsAuthConfig:
+                            properties:
+                              roleARN:
+                                type: string
+                            type: object
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    required:
+                    - labels
+                    type: object
+                required:
+                - metadata
+                type: object
+            required:
+            - template
+            type: object
+          status:
+            description: ClusterSetStatus defines the observed state of ClusterSet
+            properties:
+              clusters:
+                description: ClusterSetStatusClusters contains runner registration
+                  status
+                properties:
+                  names:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              lastSyncTime:
+                format: date-time
+                type: string
+              message:
+                type: string
+              phase:
+                type: string
+              reason:
+                type: string
+            required:
+            - clusters
+            - lastSyncTime
+            - message
+            - phase
+            - reason
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/main.go
+++ b/main.go
@@ -20,11 +20,13 @@ func main() {
 	var (
 		dryRun   bool
 		ns       string
+		roleARN  string
 		name     string
 		endpoint string
 		caData   string
 		eksTags  []string
 		labelKVs []string
+		awsAuthConfigRoleARN string
 	)
 
 	cmd := &cobra.Command{
@@ -35,11 +37,13 @@ func main() {
 
 	flag.BoolVar(&dryRun, "dry-run", false, "")
 	flag.StringVar(&ns, "namespace", "", "")
+	flag.StringVar(&roleARN, "role-arn", "", "")
 	flag.StringVar(&name, "name", "", "")
 	flag.StringVar(&endpoint, "endpoint", "", "")
 	flag.StringVar(&caData, "ca-data", "", "")
 	flag.StringSliceVar(&eksTags, "eks-tags", nil, "Comma-separated KEY=VALUE pairs of EKS control-plane tags")
 	flag.StringSliceVar(&labelKVs, "labels", nil, "Comma-separated KEY=VALUE pairs of cluster secret labels")
+	flag.StringVar(&awsAuthConfigRoleARN, "aws-auth-config-role-arn", "", "")
 
 	newLabels := func() map[string]string {
 		labels := map[string]string{}
@@ -51,10 +55,12 @@ func main() {
 		return run.Config{
 			DryRun:   dryRun,
 			NS:       ns,
+			RoleARN: roleARN,
 			Name:     name,
 			Endpoint: endpoint,
 			CAData:   caData,
 			Labels:   newLabels(),
+			AwsAuthConfigRoleARN: awsAuthConfigRoleARN,
 		}
 	}
 
@@ -66,10 +72,12 @@ func main() {
 		}
 
 		setConfig := run.ClusterSetConfig{
-			DryRun:  dryRun,
-			NS:      ns,
-			EKSTags: tags,
-			Labels:  newLabels(),
+			DryRun:               dryRun,
+			NS:                   ns,
+			RoleARN:              roleARN,
+			EKSTags:              tags,
+			Labels:               newLabels(),
+			AWSAuthConfigRoleARN: awsAuthConfigRoleARN,
 		}
 
 		return setConfig

--- a/pkg/awsclicompat/awsclicompat.go
+++ b/pkg/awsclicompat/awsclicompat.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"os"
 )
 
@@ -18,7 +19,7 @@ import (
 //
 // The fourth option of using FORCE_AWS_PROFILE=true and AWS_PROFILE=yourprofile is equivalent to `aws --profile ${AWS_PROFILE}`.
 // See https://github.com/variantdev/vals/issues/19#issuecomment-600437486 for more details and why and when this is needed.
-func NewSession(region, profile string) *session.Session {
+func NewSession(region, profile, roleARN string) *session.Session {
 	var cfg *aws.Config
 	if region != "" {
 		cfg = aws.NewConfig().WithRegion(region)
@@ -38,6 +39,11 @@ func NewSession(region, profile string) *session.Session {
 	}
 
 	sess := session.Must(session.NewSessionWithOptions(opts))
+
+	if roleARN != "" {
+		creds := stscreds.NewCredentialsWithClient(sts.New(sess), roleARN)
+		return sess.Copy(&aws.Config{Credentials: creds})
+	}
 
 	return sess
 }

--- a/pkg/controllers/clusterset.go
+++ b/pkg/controllers/clusterset.go
@@ -99,10 +99,12 @@ func (r *ClusterSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	}
 
 	config := run.ClusterSetConfig{
-		DryRun:  false,
-		NS:      req.Namespace,
-		EKSTags: clusterSet.Spec.Selector.EKSTags,
-		Labels:  clusterSet.Spec.Template.Metadata.Labels,
+		DryRun:               false,
+		NS:                   req.Namespace,
+		RoleARN:              clusterSet.Spec.Selector.RoleARN,
+		EKSTags:              clusterSet.Spec.Selector.EKSTags,
+		Labels:               clusterSet.Spec.Template.Metadata.Labels,
+		AWSAuthConfigRoleARN: clusterSet.Spec.Template.Metadata.Config.AWSAuthConfig.RoleARN,
 	}
 
 	if err := run.Sync(config); err != nil {


### PR DESCRIPTION
no assume role logs
```
2021/02/22 08:55:40 Calling EKS ListClusters...
2021-02-22T08:55:43.093Z        ERROR   controllers.ClusterSet  Syncing clusters        {"clusterSet": "default/myclusterset1", "error": "creating missing cluster secrets: processing first set of EKS clusters: listing clusters: AccessDenied: User: arn:aws:sts::123456789012:assumed-role/... is not authorized to perform: sts:AssumeRole on resource: 123456789012:role/read-eks-cluster-role\n\tstatus code: 403, request id: 027fcae8-cc5a-443e-809e-bfcc79c22dbf", "errorVerbose": "creating missing cluster secrets:\n    github.com/mumoshu/argocd-clusterset/pkg/run.Sync\n        /workspace/pkg/run/run.go:223\n  - processing first set of EKS clusters:\n    github.com/mumoshu/argocd-clusterset/pkg/run.clusterSecretsFromClusters\n        /workspace/pkg/run/run.go:284\n  - listing clusters:\n    github.com/mumoshu/argocd-clusterset/pkg/run.clusterSecretsFromClusters.func1\n        /workspace/pkg/run/run.go:248\n  - AccessDenied: User: arn:aws:sts::832907449145:assumed-role/kkaizu-sandbox-worker/i-0f290e9b8db64927c is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::619848334987:role/kkaizu-sandbox-role-terraform\n\tstatus code: 403, request id: 027fcae8-cc5a-443e-809e-bfcc79c22dbf"}
```

generated secret
```sh
> kubectl get secret cluster-name --template={{.data.config}} | base64 -D
{
      "awsAuthConfig": {
        "clusterName": "cluster-name",
        "roleARN": "arn:aws:iam::123456789012:role/argocd-auth-role"
      },
      "tlsClientConfig": {
        "insecure": false,
        "caData": "LS..."
      }
    }
```